### PR TITLE
Substantial rewrite for efficiency and flexibilty; support for some new API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Backups
+*~
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/hass_test.py
+++ b/hass_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# "Unit test" for Home Assistent component.  Doesn't actually test anything,
+# just instantiates the component and then prints what will be passed along
+# to Home Assistant.
+#
+# ** IMPORTANT **
+#
+# If the following parameters are not changed, it will use the default cache
+# file which *MUST* be initialised with credentials.  If this has not been
+# created by other means, either modify `user` and `pw` as appropriate OR
+# create a cache file using the CLI tool:
+#
+#       sp-cli.py -e user@domain.com -p SECRET --update
+#
+# If using a non-default cache file:
+#
+#       sp-cli.py -c /path/to/cache-file -e user@domain.com -p SECRET --update
+
+user = None
+pw = None
+cache_file = None
+
+import home_assistant.sure_petflap as Dut
+
+from pprint import pprint
+import json
+
+dut = Dut.SurePetConnect( user, pw, debug = True, cache_file = cache_file )
+
+
+print( '--- state (decoded JSON):' )
+pprint( json.loads( dut.state ) )
+
+print( '\n--- state attributes:' )
+pprint( dut.state_attributes )

--- a/home_assistant/__init__.py
+++ b/home_assistant/__init__.py
@@ -1,0 +1,1 @@
+# Stub to make the hass component importable for testing.

--- a/home_assistant/sure_petflap.py
+++ b/home_assistant/sure_petflap.py
@@ -2,15 +2,46 @@ import logging
 from datetime import timedelta
 import json
 
-import voluptuous as vol
+def is_hass_component():
+    try:
+        import homeasssistant
+        return True
+    except ImportError:
+        return False
 
-from homeassistant.helpers.entity import Entity
-import homeassistant.util as util
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
-import homeassistant.helpers.config_validation as cv
+if is_hass_component():
+    from homeassistant.helpers.entity import Entity
+    from homeassistant.util import Throttle
+    from homeassistant.components.sensor import PLATFORM_SCHEMA
+    from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+    import homeassistant.helpers.config_validation as cv
 
-from deps.sure_petcare import *
+    from deps.sure_petcare import SurePetFlap
+    from deps.sure_petcare.utils import gen_device_id
+
+    import voluptuous as vol
+
+    PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    })
+else:
+    # Assume not running within home assistant.  This *does* mean that you
+    # won't be able to run this test script if you have homeassistant
+    # installed but, if you do, you're probably running (or can run) this
+    # component from within hass anyway.
+    from sure_petcare import SurePetFlap
+    from sure_petcare.utils import gen_device_id
+
+    # dummy dependencies
+    class Entity( object ):
+        pass
+
+    def Throttle( *args, **kwargs ):
+        def decorator( f ):
+            return f
+        return decorator
+
 
 #REQUIREMENTS = ['sure_petcare']
 
@@ -18,11 +49,6 @@ from deps.sure_petcare import *
 _LOGGER = logging.getLogger(__name__)
 
 CONF_device_id = 'device_id'
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-})
 
 SCAN_INTERVAL = timedelta(seconds=300)
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=600)
@@ -38,15 +64,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SurePetConnect(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, username, password):
+    def __init__(self, username, password, **kwargs):
         """Initialize the sensor."""
         _LOGGER.debug('Initializing...')
-        #guestimate, low voltage=1.0V/cell, need to measure low voltage battery
-        self.LOW_BATTERY_VOLTAGE = 4.0 
+        # 1.25V is a fairly conservative guess for alkalines.  If you use
+        # rechargeables, you may need to change this.
+        self.FULL_BATTERY_VOLTAGE = 1.6 # volts
+        self.LOW_BATTERY_VOLTAGE = 1.25 # volts
         self.battery = [-1] *60
         self.battery[0] = 1 # Initialize average so we have a mean
         self.battery_pos = -1
-        self.sure = SurePetFlap(email_address=username, password=password, device_id=gen_device_id())
+        self.sure = SurePetFlap(email_address=username, password=password, device_id=gen_device_id(), **kwargs)
         self._state = None
         self._attributes = []
         self.update()
@@ -66,7 +94,7 @@ class SurePetConnect(Entity):
         """Return the unit of measurement."""
         return ''
     
-    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+    @Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Fetch new state data for the sensor.
 
@@ -74,16 +102,30 @@ class SurePetConnect(Entity):
         """
         _LOGGER.debug('Returning current state...')
         flap_status = {}
-        self.sure.update()
-        for pet in  self.sure.pets:
+        with self.sure:
+            # Update only data required
+            self.sure.update_authtoken()
+            self.sure.update_households()
+            self.sure.update_device_ids()
+            self.sure.update_pet_info()
+            self.sure.update_pet_status()
+            self.sure.update_flap_status()
+            self.sure.update_router_status()
+        for pet in self.sure.pets:
             pet_status = self.sure.get_current_status(pet)
             flap_status[str(self.sure.pets[pet]['name'])]  = pet_status
         self.battery_pos = (self.battery_pos + 1) % len(self.battery) #Loop around
-        self.battery[self.battery_pos] = int((self.sure.flap_status['data']['battery'] - self.LOW_BATTERY_VOLTAGE)/(6.0-self.LOW_BATTERY_VOLTAGE)*100)
+        # NB: Units have changed.  Earlier versions reported the raw voltage
+        #     direct from the Sure backend which was the sum of the four
+        #     batteries.  The current API reports voltage per battery, making
+        #     it easier to set thresholds based on battery chemistry.
+        bat_left = self.sure.battery - self.LOW_BATTERY_VOLTAGE
+        bat_full = self.FULL_BATTERY_VOLTAGE - self.LOW_BATTERY_VOLTAGE
+        self.battery[self.battery_pos] = int(bat_left/bat_full*100)
         flap_status['avg_battery'] = int(self.mean([ i for i in self.battery if i > 0]))
         flap_status['battery'] = self.battery[self.battery_pos]
-        flap_status['flap_online']  = self.sure.flap_status['data']['online'] 
-        flap_status['hub_online'] =  self.sure.router_status['data']['online']
+        flap_status['flap_online']  = self.sure.flap_status[self.sure.default_flap]['online']
+        flap_status['hub_online'] =  self.sure.router_status[self.sure.default_router]['online']
         flap_status['lock_status'] = self.sure.lock_mode()
         flap_status['locked'] = self.sure.locked()
         _LOGGER.debug('State: ' + str(flap_status))

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(name='sure_petcare',
       author_email='rene@castberg.org',
       license='GPL',
       packages=['sure_petcare'],
+      scripts=['sp_cli.py'],
       zip_safe=False)

--- a/sp_cli.py
+++ b/sp_cli.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+import sure_petcare
+
+def main( argv ):
+    description = """\
+Sure Petcare Connect CLI
+
+--- *WARNING* ---
+    
+This is not officially sanctioned software and may or may not violate the terms
+of service.  Use this software and the API at your own risk!  Since the API on
+which this is based is also unofficial and reverse engineered, there is no
+guarantee that Sure won't change the API in a way to break this software.
+
+*ON NO ACCOUNT* bother Sure customer support with questions about either this
+tool or the API.  As excellent Sure's support team are, they don't know
+anything about it and can't help you.  If you have a problem, file an Issue on
+Github with the fork you got this from.
+
+This CLI is supposed to be an EXAMPLE of how to use the API, not a substitute
+for writing your own client to do the minimal amount of work.
+    
+-----------------
+
+As with Sure's REST API, this API is under development and is not any more
+guaranteed to maintain interface compatibility going forward.
+
+Because use of this tool involves storing your account username and password in
+cleartext, you might want to create a view-only user and add it to your
+household.
+
+General instructions:
+
+    * First use: %(prog)s --update -e <email_address> -p <password>
+
+    * Subsequently: %(prog)s --update
+
+After update, you can use any of the following switches to query the status of
+your pets, flap or household.  Note that --update is mutually exclusive with any
+other option (other than --email or --pass)."""
+
+    parser = argparse.ArgumentParser( description = description, formatter_class = argparse.RawDescriptionHelpFormatter )
+    parser.add_argument( '-e', '--email',
+                         help = 'account email address' )
+    parser.add_argument( '-p', '--pass', dest = 'pw',
+                         help = 'account password' )
+    parser.add_argument( '--update', action = 'store_true',
+                         help = 'update cache from Sure servers.  Mutually exclusive with commands/queries.' )
+    parser.add_argument( 'cmd', nargs = '*',
+                         help = 'One of ' + ', '.join( sorted(CMDS.keys()) ) )
+    args = parser.parse_args()
+
+    if args.update and args.cmd:
+        exit( '--update and commands/queries are mutually exclusive' )
+
+    if not args.update and not args.cmd:
+        parser.print_help()
+        exit()
+
+    debug = os.environ.get( 'SPDEBUG' ) is not None
+    cachefile = os.environ.get( 'SPCACHE', sure_petcare.CACHE_FILE )
+    sp = sure_petcare.SurePetFlap( email_address = args.email,
+                                   password = args.pw,
+                                   cache_file = cachefile,
+                                   debug = debug )
+
+    if args.update:
+        # Either update and write the cache, or...
+        with sp:
+            sp.update()
+    else:
+        # ... execute queries on cached data
+        if args.cmd[0] in CMDS:
+            CMDS[args.cmd[0]]( sp, args )
+        else:
+            exit( 'Unknown command: %s' % (args.cmd[0],) )
+
+CMDS = {}
+def cmd( f ):
+    if f.__name__.startswith( 'cmd_' ):
+        fn = f.__name__[4:]
+        CMDS[fn] = f
+    else:
+        raise ValueError( 'bad use of @cmd decorator: %s' % (f.__name__,) )
+    return f
+
+from pprint import pprint
+
+@cmd
+def cmd_ls_house( sp, args ):
+    """
+    List households
+    """
+    for hid, hdata in sp.households.items():
+        default_flag = (hid == sp.default_household) and '(active)' or ''
+        print( '%s\t%s %s' % (hid, hdata['name'], default_flag,) )
+
+
+@cmd
+def cmd_ls_pets( sp, args ):
+    """
+    For each pet in household, show location (inside, outside, unknown)
+    """
+    for pid, pdata in sp.pets.items():
+        print( '%s (%s) is %s' % (pdata['name'], pid, sp.get_current_status( pid ),) )
+
+
+@cmd
+def cmd_ls_flaps( sp, args ):
+    """
+    For each pet in household, show location (inside, outside, unknown)
+    """
+    for flap_id, name in sp.household['flaps'].items():
+        bat = sp.get_battery( flap_id = flap_id )
+        lck = sp.lock_mode( flap_id )
+        print( '%s (%s) at %05.3fV is %s' % (name, flap_id, bat, lck,) )
+
+
+@cmd
+def cmd_pet_tl( sp, args ):
+    """
+    For each pet in household, show location (inside, outside, unknown)
+    """
+    try:
+        name = args.cmd[1]
+    except IndexError:
+        exit('need pet name (enclose in quotes if necessary)')
+
+    sp.print_timeline( name = name )
+
+
+@cmd
+def cmd_set_hid( sp, args ):
+    """
+    Set default household ID
+    """
+    try:
+        hid = int(args.cmd[1])
+    except (ValueError, IndexError,):
+        exit( 'need valid household ID' )
+
+    if hid in sp.households:
+        with sp:
+            sp.default_household = hid
+            if sp.update_required:
+                sp.update()
+    else:
+        exit( 'Household ID %s not known' % (hid,) )
+
+if __name__ == '__main__':
+    main( sys.argv )

--- a/sp_cli.py
+++ b/sp_cli.py
@@ -51,6 +51,8 @@ other option (other than --email or --pass)."""
                          help = 'account password' )
     parser.add_argument( '--update', action = 'store_true',
                          help = 'update cache from Sure servers.  Mutually exclusive with commands/queries.' )
+    parser.add_argument( '-c', '--cache-file',
+                         help = 'Cache file to use if not default' )
     parser.add_argument( 'cmd', nargs = '*',
                          help = 'One of ' + ', '.join( sorted(CMDS.keys()) ) )
     args = parser.parse_args()
@@ -63,10 +65,9 @@ other option (other than --email or --pass)."""
         exit()
 
     debug = os.environ.get( 'SPDEBUG' ) is not None
-    cachefile = os.environ.get( 'SPCACHE', sure_petcare.CACHE_FILE )
     sp = sure_petcare.SurePetFlap( email_address = args.email,
                                    password = args.pw,
-                                   cache_file = cachefile,
+                                   cache_file = args.cache_file,
                                    debug = debug )
 
     if args.update:
@@ -89,7 +90,6 @@ def cmd( f ):
         raise ValueError( 'bad use of @cmd decorator: %s' % (f.__name__,) )
     return f
 
-from pprint import pprint
 
 @cmd
 def cmd_ls_house( sp, args ):

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -113,13 +113,13 @@ class SurePetFlapAPI(object):
     @property
     def default_household( self ):
         """
-        Get the default house ID from the persistent cache.
+        Get the default house ID.
         """
         return self.cache['default_household']
     @default_household.setter
     def default_household( self, id ):
         """
-        Set the default household in the persistent cache.
+        Set the default household.
         """
         self.cache['default_household'] = id
     @property
@@ -140,23 +140,23 @@ class SurePetFlapAPI(object):
 
     def get_default_router( self, hid ):
         """
-        Set the default router ID in the persistent cache.
+        Set the default router ID.
         """
         return self.cache['households'][hid]['default_router']
     def set_default_router( self, hid, rid ):
         """
-        Get the default router ID from the persistent cache.
+        Get the default router ID.
         """
         self.cache['households'][hid]['default_router'] = rid
 
     def get_default_flap( self, hid ):
         """
-        Get the default flap ID from the persistent cache.
+        Get the default flap ID.
         """
         return self.cache['households'][hid]['default_flap']
     def set_default_flap( self, hid, fid ):
         """
-        Set the default flap ID in the persistent cache.
+        Set the default flap ID.
         """
         self.cache['households'][hid]['default_flap'] = fid
 
@@ -169,7 +169,7 @@ class SurePetFlapAPI(object):
 
     def get_pets( self, hid = None ):
         """
-        Return dict of pets.
+        Return dict of pets.  Default household used if not specified.
         """
         hid = hid or self.default_household
         return self.cache['households'][hid]['pets']
@@ -207,11 +207,7 @@ class SurePetFlapAPI(object):
     def get_pet_location(self, pet_id, household_id = None):
         """
         Returns one of enum LOC indicating last known movement of the pet.
-
-        Note that because sometimes the chip reader fails to read the pet
-        (especially if they exit too quickly), this function can indicate that
-        they're inside when in fact they're outside.  The same limitation
-        presumably applies to the official website and app.
+        Default household used if not specified.
         """
         household_id = household_id or self.default_household
         if pet_id not in self.pet_status[household_id]:
@@ -242,9 +238,8 @@ class SurePetFlapAPI(object):
 
     def update_authtoken(self, force = False):
         """
-        Update persistent cache with authentication token if missing.
-        Use `force = True` when the token expires (the API generally does this
-        automatically).
+        Update cache with authentication token if missing.  Use `force = True`
+        when the token expires (the API generally does this automatically).
         """
         if self.cache['AuthToken'] is not None and not force:
             return
@@ -261,8 +256,7 @@ class SurePetFlapAPI(object):
 
     def update_households(self, force = False):
         """
-        Update persistent cache with info about the household(s) associated with
-        the account.
+        Update cache with info about the household(s) associated with the account.
         """
         if self.cache['households'] is not None and not force:
             return
@@ -284,8 +278,8 @@ class SurePetFlapAPI(object):
 
     def update_device_ids(self, force = False):
         """
-        Update persistent cache with list of router and flap IDs for each
-        household.  The default router and flap are the first ones found.
+        Update cache with list of router and flap IDs for each household.  The
+        default router and flap are set to the first ones found.
         """
         household = self.cache['households'][self.default_household]
         if (household['default_router'] is not None and
@@ -309,7 +303,7 @@ class SurePetFlapAPI(object):
 
     def update_pet_info(self, force = False):
         """
-        Update persistent cache pet information.
+        Update cache with pet information.
         """
         if self.cache['households'].get('pets') is not None and not force:
             return
@@ -328,7 +322,7 @@ class SurePetFlapAPI(object):
 
     def update_flap_status(self, hid = None):
         """
-        Update flap status (via transient cache, default all).
+        Update flap status.  Default household used if not specified.
 
         To minimise API traffic, please specify a household ID if you can.
         """
@@ -343,7 +337,8 @@ class SurePetFlapAPI(object):
     def update_router_status(self, hid = None):
         """
         Update router status.  Don't call unless you really need to because
-        there's not much of interest here.  Defaults to all.
+        there's not much of interest here.  Default household used if not
+        specified.
 
         To minimise API traffic, please specify a household ID if you can.
         """
@@ -357,8 +352,8 @@ class SurePetFlapAPI(object):
 
     def update_house_timeline(self, hid = None):
         """
-        Update household event timeline (via transient cache) and curfew lock
-        status.  Defaults to all.
+        Update household event timeline and curfew lock status.  Default
+        household used if not specified.
 
         To minimise API traffic, please specify a household ID if you can.
         """
@@ -380,7 +375,7 @@ class SurePetFlapAPI(object):
 
     def update_pet_status(self, hid = None):
         """
-        Update pet status via transient cache.  Defaults to all households.
+        Update pet timeline.  Default household used if not specified.
 
         To minimise API traffic, please specify a household ID if you can.
         """

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -13,8 +13,8 @@ from .utils import mk_enum
 
 CACHE_FILE = os.path.expanduser( '~/.surepet.cache' )
 
-DIRECTION ={0:'looked through',1:'entered house',2:'left house'}
-INOUT_STATUS = {1 : 'inside', 2 : 'outside'}
+DIRECTION ={0:'Looked through',1:'Entered House',2:'Left House'}
+INOUT_STATUS = {1 : 'Inside', 2 : 'Outside'}
 
 # The following event types are known, eg EVT.CURFEW.
 EVT = mk_enum( 'EVT',

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -116,8 +116,8 @@ class SurePetFlapAPI(object):
         update what you need and leave context as soon as possible.
         """
         # cache_status is None to indicate that it hasn't been initialised
-        self.cache_file = cache_file
-        self.cache_lockfile = cache_file + '.lock'
+        self.cache_file = cache_file or CACHE_FILE
+        self.cache_lockfile = self.cache_file + '.lock'
         # Must store household_id because _load_cache() gets called by
         # __enter__()
         self._init_default_household = household_id
@@ -612,7 +612,7 @@ class SurePetFlapAPI(object):
         try:
             with open( self.cache_file, 'rb' ) as f:
                 self.cache = pickle.load( f )
-        except pickle.PickleError: # let file errors pass to caller
+        except (pickle.PickleError, OSError,):
             self.cache = {'AuthToken': None,
                           'households': None,
                           'default_household': self._init_default_household,

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -63,8 +63,9 @@ class SurePetFlapAPI(object):
     """
 
     def __init__(self, email_address=None, password=None, device_id=None, cache=None, debug=False):
-        """`email_address` and `password` are self explanatory and are the only
-        mandatory arguments.
+        """
+        `email_address` and `password` are self explanatory.  They are
+        mandatory if a populated `cache` object is not supplied.
 
         `device_id` is the ID of *this* client.  If none supplied, a plausible,
         unique-ish default is supplied.
@@ -77,6 +78,9 @@ class SurePetFlapAPI(object):
         it also means you don't need to supply your email and password again
         unless they change.
 
+        Unless supplied with a populated `cache` object, the new instance
+        remains unpopulated (and unusable) until method `update()` has been
+        called.
         """
         if (email_address is None or password is None) and cache is None:
             raise ValueError('Please provide, email, password and device id')
@@ -202,7 +206,7 @@ class SurePetFlapAPI(object):
 
     def get_pet_location(self, pet_id, household_id = None):
         """
-        Returns a string describing the last known movement of the pet.
+        Returns one of enum LOC indicating last known movement of the pet.
 
         Note that because sometimes the chip reader fails to read the pet
         (especially if they exit too quickly), this function can indicate that

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -32,6 +32,7 @@ class SurePetFlap(object):
         self.s = requests.session()
         self.email_address = email_address
         self.password = password
+        self.AuthToken = None
         self.device_id = device_id
         self.update()
 
@@ -142,7 +143,9 @@ class SurePetFlap(object):
             self.tcache[url]={}
             headers = self.create_header()
         response = self.s.get(url, headers=headers, params=params)
-        if response.status_code == 304:
+        if response.status_code in [304, 500, 502, 503,]:
+            # Used cached data in event of (respectively), not modified, server
+            # error, server overload and gateway timeout
             #print('Got a 304')
             return self.tcache[url]['LastData']
         self.tcache[url]['LastData'] = response.json()
@@ -288,4 +291,4 @@ def getmac():
 def gen_device_id():
     mac_dec = int( getmac().replace( ':', '').replace( '-', '' ), 16 )
     # Use low order bits because upper two octets are low entropy
-    return str(mac_dec[-10:])
+    return str(mac_dec)[-10:]

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -165,7 +165,7 @@ class SurePetFlap(object):
             if time_since_last.total_seconds() < refresh_interval: #Refresh every hour at least
                 headers = self.create_header(ETag=self.tcache[url]['ETag'])
             else:
-                self.debug_print('Refreshing data')
+                self.debug_print('Using cached data for %s' % (url,))
         if headers is None:
             self.tcache[url]={}
             headers = self.create_header()

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -247,11 +247,11 @@ class SurePetFlapAPI(object):
         "Returns the default router ID for the default household"
         return self.get_default_router()
     def get_default_router( self, household_id = None ):
-        "Set the default router ID."
+        "Get the default router ID."
         household_id = household_id or self.default_household
         return self.households[household_id]['default_router']
     def set_default_router( self, household_id, rid ):
-        "Get the default router ID."
+        "Set the default router ID."
         if self.__read_only:
             raise SPAPIReadOnly()
         self.households[household_id]['default_router'] = rid
@@ -293,6 +293,10 @@ class SurePetFlapAPI(object):
 
     @property
     def router_status( self ):
+        "Dict of all routers in default household"
+        return self.all_router_status[self.default_household]
+    @property
+    def all_router_status( self, household_id = None ):
         "Dict of all routers indexed by household and router IDs"
         return self.cache['router_status']
     @property

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -104,10 +104,12 @@ class SurePetFlap(object):
 
     def update_authtoken(self):
         """Get authentication token from servers"""
-        data = '{"email_address":"' + self.email_address + '","password":"' + self.password + \
-                '","device_id":"' + self.device_id + '"}'
-        headers=self.create_header(Content_length=88)
-        response = self.s.post(URL_AUTH, headers=headers, data=data)
+        data = {"email_address": self.email_address,
+                "password": self.password,
+                "device_id": self.device_id,
+                }
+        headers=self.create_header()
+        response = self.s.post(URL_AUTH, headers=headers, json=data)
         response_data = json.loads(response.content.decode('utf-8'))
         self.AuthToken = response_data['data']['token']
 
@@ -223,18 +225,18 @@ class SurePetFlap(object):
                     return STATUS_INOUT[movement['movements'][0]['direction']]
             return 'Unknown'
 
-    def create_header(self, Content_length='0', Authorization=None, ETag=None):
-        headers={'Host': 'app.api.surehub.io',
-        'Connection': 'keep-alive',
-        'Accept': 'application/json, text/plain, */*',
-        'Origin': 'https://surepetcare.io',
-        'User-Agent': API_USER_AGENT,
-        'Content-Type': 'application/json;charset=UTF-8',
-        'Referer': 'https://surepetcare.io/',
-        'Accept-Encoding': 'gzip, deflate',
-        'Accept-Language': 'en-US,en-GB;q=0.9',
-        'X-Requested-With': 'com.sureflap.surepetcare'}
-        headers['Content-Length']=str(Content_length)
+    def create_header(self, Authorization=None, ETag=None):
+        headers={
+            'Connection': 'keep-alive',
+            'Accept': 'application/json, text/plain, */*',
+            'Origin': 'https://surepetcare.io',
+            'User-Agent': API_USER_AGENT,
+            'Referer': 'https://surepetcare.io/',
+            'Accept-Encoding': 'gzip, deflate',
+            'Accept-Language': 'en-US,en-GB;q=0.9',
+            'X-Requested-With': 'com.sureflap.surepetcare',
+        }
+
         if Authorization is not None:
             headers['Authorization']='Bearer ' + Authorization
         if ETag is not None:

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -87,7 +87,7 @@ class SurePetFlapAPI(object):
                           'flap_status': {}, # indexed by household
                           'pet_status': {}, # indexed by household
                           'house_timeline': {}, # indexed by household
-                          'curfew_lock_info': {}, # indexed by household
+                          'curfew_locked': {}, # indexed by household
                           }
         else:
             self.cache = cache
@@ -122,8 +122,8 @@ class SurePetFlapAPI(object):
     def house_timeline( self ):
         return self.cache['house_timeline']
     @property
-    def curfew_lock_info( self ):
-        return self.cache['curfew_lock_info']
+    def curfew_locked( self ):
+        return self.cache['curfew_locked']
 
     def get_default_router( self, hid ):
         """
@@ -310,10 +310,10 @@ class SurePetFlapAPI(object):
             curfew_events = [x for x in htl if x['type'] == EVT.CURFEW]
             if curfew_events:
                 # Serialised JSON within a serialised JSON structure?!  Weird.
-                self.cache['curfew_lock_info'][hid] = json.loads(curfew_events[0]['data'])['locked']
+                self.cache['curfew_locked'][hid] = json.loads(curfew_events[0]['data'])['locked']
             else:
                 # new accounts might not be populated with the relevent information
-                self.cache['curfew_lock_info'][hid] = None
+                self.cache['curfew_locked'][hid] = None
 
     def update_pet_status(self, hid = None):
         """
@@ -448,7 +448,7 @@ class SurePetFlapMixin( object ):
         if lock in [LK_MOD.LOCKED_IN, LK_MOD.LOCKED_OUT, LK_MOD.LOCKED_ALL,]:
             return True
         if lock == LK_MOD.CURFEW:
-            if self.curfew_lock_info[household_id]:
+            if self.curfew_locked[household_id]:
                 return True
             else:
                 return False
@@ -473,9 +473,9 @@ class SurePetFlapMixin( object ):
             return 'Locked'
         elif lock == LK_MOD.CURFEW:
             #We are in curfew mode, check log to see if in locked or unlocked.
-            if self.curfew_lock_info[household_id] is None:
+            if self.curfew_locked[household_id] is None:
                 return 'Curfew enabled but state unknown'
-            elif self.curfew_lock_info[household_id]:
+            elif self.curfew_locked[household_id]:
                 return 'Locked with curfew'
             else:
                 return 'Unlocked with curfew'

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -430,10 +430,9 @@ class SurePetFlapAPI(object):
         if headers is None:
             headers = self._create_header()
         response = self._api_get(url, headers=headers, params=params)
-        if response.status_code in [304, 500, 502, 503,]:
+        if response.status_code in [304, 500, 502, 503, 504,]:
             # Used cached data in event of (respectively), not modified, server
-            # error, server overload and gateway timeout
-            #print('Got a 304')
+            # error, server overload, server unavailable and gateway timeout
             return self.cache[url]['LastData']
         self.cache[url]['LastData'] = response.json()
         self.cache[url]['ETag'] = response.headers['ETag'][1:-1]

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -88,6 +88,7 @@ class SurePetFlapAPI(object):
         self.debug=debug
         self.s = requests.session()
         if debug:
+            self.req_count = self.req_rx_bytes = 0
             self.s.hooks['response'].append( self._log_req )
         if device_id is None:
             self.device_id = utils.gen_device_id()
@@ -470,7 +471,11 @@ class SurePetFlapAPI(object):
         """
         Debugging aid: print network requests
         """
-        print( 'requests: %s %s -> %s' % (r.request.method, r.request.url, r.status_code,) )
+        l = len( '\n'.join( ': '.join(x) for x in r.headers.items() ) )
+        l += len(r.content)
+        self.req_count += 1
+        self.req_rx_bytes += l
+        print( 'requests: %s %s -> %s (%0.3f kiB, total %0.3f kiB in %s requests)' % (r.request.method, r.request.url, r.status_code, l/1024.0, self.req_rx_bytes/1024.0, self.req_count,) )
 
 
 class SurePetFlapMixin( object ):

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -417,17 +417,17 @@ class SurePetFlapAPI(object):
         params = (
             ('with[]', 'children'),
         )
-        routers = household['routers'] = []
-        flaps = household['flaps'] = []
+        routers = household['routers'] = {}
+        flaps = household['flaps'] = {}
         url = '%s/%s/device' % (_URL_HOUSEHOLD, household_id,)
         response_children = self._get_data(url, params)
         for device in response_children['data']:
             if device['product_id'] == PROD_ID.FLAP: # Catflap
-                flaps.append( device['id'] )
+                flaps[device['id']] = device['name']
             elif device['product_id'] == PROD_ID.ROUTER: # Router
-                routers.append( device['id'] )
-        household['default_flap'] = flaps[0]
-        household['default_router'] = routers[0]
+                routers[device['id']] = device['name']
+        household['default_flap'] = list(flaps.keys())[0]
+        household['default_router'] = list(routers.keys())[0]
 
     def update_pet_info( self, household_id = None, force = False ):
         """

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -305,7 +305,9 @@ class SurePetFlapMixin( object ):
             return 'Locked'
         elif lock == 4:
             #We are in curfew mode, check log to see if in locked or unlocked.
-            if self.curfew_lock_info:
+            if self.curfew_lock_info == 'Unknown':
+                return 'Curfew enabled but state unknown'
+            elif self.curfew_lock_info:
                 return 'Locked with curfew'
             else:
                 return 'Unlocked with curfew'

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -86,8 +86,6 @@ class SurePetFlapNetwork(object):
         else:
             self.tcache = tcache
 
-        self.update()
-
     def update(self):
         self.update_authtoken()
         self.update_household_id()

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -14,6 +14,7 @@ INOUT_STATUS = {1 : 'Inside', 2 : 'Outside'}
 
 # The following event types are known, eg EVT.CURFEW.
 EVT = (('MOVE', 0),
+       ('MOVE_UID', 7), # movement of unknown animal
        ('LOCK_ST', 6),
        ('USR_IFO', 12),
        ('USR_NEW', 17),
@@ -123,6 +124,12 @@ class SurePetFlapNetwork(object):
         Set the default flap ID in the persistent cache.
         """
         self.pcache['households'][hid]['default_flap'] = fid
+
+    def get_households( self ):
+        """
+        Return dict of households.
+        """
+        return self.pcache['households']
 
     def get_pets( self, hid = None ):
         """
@@ -386,7 +393,7 @@ class SurePetFlapMixin( object ):
         petdata = self.pet_status[household_id][pet_id]
 
         for movement in petdata:
-            if movement['type'] in [EVT.LOCK_ST, EVT.USR_IFO, EVT.USR_NEW, EVT.CURFEW]:
+            if movement['type'] in [EVT.MOVE_UID, EVT.LOCK_ST, EVT.USR_IFO, EVT.USR_NEW, EVT.CURFEW]:
                 continue
             try:
                 if entry_type is not None:

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -260,17 +260,22 @@ class SurePetFlapMixin( object ):
 
     def print_timeline(self, petid, entry_type=None):
         """Print timeline for a particular pet, specify entry_type to only get one direction"""
+        try:
+            tag_id = self.pcache['pets'][petid]['tag_id']
+        except KeyError as e:
+            raise SPAPIUnknownPet( str(e) )
         petdata = self.petstatus[petid]
+
         for movement in petdata['data']:
             if movement['type'] in [EVT.LOCK_ST, EVT.USR_IFO, EVT.USR_NEW, EVT.CURFEW]:
                 continue
             try:
                 if entry_type is not None:
-                    if movement['movements'][0]['tag_id'] == petid:
+                    if movement['movements'][0]['tag_id'] == tag_id:
                         if movement['movements'][0]['direction'] == entry_type:
                             print(movement['movements'][0]['created_at'], DIRECTION[movement['movements'][0]['direction']])
                 else:
-                    if movement['movements'][0]['tag_id'] == petid:
+                    if movement['movements'][0]['tag_id'] == tag_id:
                         print(movement['movements'][0]['created_at'], DIRECTION[movement['movements'][0]['direction']])
             except Exception as e:
                 print(e)
@@ -348,6 +353,10 @@ class SPAPIException( Exception ):
 
 
 class SPAPIAuthError( SPAPIException ):
+    pass
+
+
+class SPAPIUnknownPet( SPAPIException ):
     pass
 
 

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -70,7 +70,7 @@ class SurePetFlapAPI(object):
     below.
     """
 
-    def __init__(self, email_address=None, password=None, household_id=None, device_id=None, cache_file=CACHE_FILE, debug=False):
+    def __init__( self, email_address = None, password = None, household_id = None, device_id = None, cache_file = CACHE_FILE, debug = False ):
         """
         `email_address` and `password` are self explanatory.  They are cached on
         disc file `cache_file` and are therefore only mandatory on first
@@ -108,8 +108,8 @@ class SurePetFlapAPI(object):
         ```
         with SurePetFlap() as api:
             api.update_pet_status()
-        for pid, info in api.pets.items():
-            print( '%s is %s' % (info['name'], api.get_pet_location(pid),) )
+        for pet_id, info in api.pets.items():
+            print( '%s is %s' % (info['name'], api.get_pet_location(pet_id),) )
         ```
 
         Note that the disc copy of the cache is locked while in context, so
@@ -160,43 +160,43 @@ class SurePetFlapAPI(object):
     def battery( self ):
         "Battery level of default flap at default household"
         return self.get_battery()
-    def get_battery( self, hid = None, fid = None ):
+    def get_battery( self, household_id = None, flap_id = None ):
         """
         Return battery voltage (assuming four batteries).  The level at which
         you should replace them depends on the chemistry (type) of the battery.
         As a guide, alkalines should be replaced before they reach 1.2V.  Use
         the official app to get better advice.
         """
-        hid = hid or self.default_household
-        fid = fid or self.get_default_flap( hid )
+        household_id = household_id or self.default_household
+        flap_id = flap_id or self.get_default_flap( household_id )
         try:
-            return self.flap_status[hid][fid]['battery'] / 4.0
+            return self.flap_status[household_id][flap_id]['battery'] / 4.0
         except KeyError:
             raise SPAPIUnitialised()
 
     @property
     def pets( self ):
         return self.get_pets()
-    def get_pets( self, hid = None ):
+    def get_pets( self, household_id = None ):
         "Return dict of pets.  Default household used if not specified."
-        hid = hid or self.default_household
+        household_id = household_id or self.default_household
         try:
-            return self.households[hid]['pets']
+            return self.households[household_id]['pets']
         except KeyError:
             raise SPAPIUnitialised()
 
-    def get_pet_id_by_name(self, name, household_id = None):
+    def get_pet_id_by_name( self, name, household_id = None ):
         """
         Returns the numeric ID (not the tag ID) of the pet by name.  Match is
         case insensitive and the first pet found with that name is returned.
         Default household used if not specified.
         """
         household_id = household_id or self.default_household
-        for petid, petdata in self.get_pets( household_id ).items():
+        for pet_id, petdata in self.get_pets( household_id ).items():
             if petdata['name'].lower() == name.lower():
-                return petid
+                return pet_id
 
-    def get_pet_location(self, pet_id, household_id = None):
+    def get_pet_location( self, pet_id, household_id = None ):
         """
         Returns one of enum LOC indicating last known movement of the pet.
         Default household used if not specified.
@@ -206,7 +206,7 @@ class SurePetFlapAPI(object):
             raise SPAPIUnknownPet()
         return self.pet_status[household_id][pet_id]['where']
 
-    def get_lock_mode(self, flap_id = None, household_id = None):
+    def get_lock_mode( self, flap_id = None, household_id = None ):
         """
         Returns one of enum LK_MOD indicating flap lock mode.  Default household
         and flap used if not specified.
@@ -248,29 +248,29 @@ class SurePetFlapAPI(object):
     def default_router( self ):
         "Returns the default router ID for the default household"
         return self.get_default_router()
-    def get_default_router( self, hid = None ):
+    def get_default_router( self, household_id = None ):
         "Set the default router ID."
-        hid = hid or self.default_household
-        return self.households[hid]['default_router']
-    def set_default_router( self, hid, rid ):
+        household_id = household_id or self.default_household
+        return self.households[household_id]['default_router']
+    def set_default_router( self, household_id, rid ):
         "Get the default router ID."
         if self.__read_only:
             raise SPAPIReadOnly()
-        self.households[hid]['default_router'] = rid
+        self.households[household_id]['default_router'] = rid
 
     @property
     def default_flap( self ):
         "Returns the default flap ID for the default household"
         return self.get_default_flap()
-    def get_default_flap( self, hid = None ):
+    def get_default_flap( self, household_id = None ):
         "Get the default flap ID."
-        hid = hid or self.default_household
-        return self.households[hid]['default_flap']
-    def set_default_flap( self, hid, fid ):
+        household_id = household_id or self.default_household
+        return self.households[household_id]['default_flap']
+    def set_default_flap( self, household_id, flap_id ):
         "Set the default flap ID."
         if self.__read_only:
             raise SPAPIReadOnly()
-        self.households[hid]['default_flap'] = fid
+        self.households[household_id]['default_flap'] = flap_id
 
     #
     # These properties return respective data for all households as a dict
@@ -322,7 +322,7 @@ class SurePetFlapAPI(object):
     # Update methods.  USE SPARINGLY!
     #
 
-    def update(self):
+    def update( self ):
         """
         Update everything.  Must be invoked once, but please, only once.  Call
         the individual update methods according to your applications needs.
@@ -339,7 +339,7 @@ class SurePetFlapAPI(object):
         #     the API call.
         self.update_house_timeline()
 
-    def update_authtoken(self, force = False):
+    def update_authtoken( self, force = False ):
         """
         Update cache with authentication token if missing.  Use `force = True`
         when the token expires (the API generally does this automatically).
@@ -359,7 +359,7 @@ class SurePetFlapAPI(object):
         response_data = response.json()
         self.cache['AuthToken'] = response_data['data']['token']
 
-    def update_households(self, force = False):
+    def update_households( self, force = False ):
         """
         Update cache with info about the household(s) associated with the account.
         """
@@ -386,15 +386,15 @@ class SurePetFlapAPI(object):
         if self.default_household not in self.households:
             self.default_household = response_household['data'][0]['id']
 
-    def update_device_ids(self, hid = None, force = False):
+    def update_device_ids( self, household_id = None, force = False ):
         """
         Update cache with list of router and flap IDs for each household.  The
         default router and flap are set to the first ones found.
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
-        household = self.households[hid]
+        household_id = household_id or self.default_household
+        household = self.households[household_id]
         if (household['default_router'] is not None and
             household['default_flap'] is not None and not force):
             return
@@ -403,7 +403,7 @@ class SurePetFlapAPI(object):
         )
         routers = household['routers'] = []
         flaps = household['flaps'] = []
-        url = '%s/%s/device' % (_URL_HOUSEHOLD, hid,)
+        url = '%s/%s/device' % (_URL_HOUSEHOLD, household_id,)
         response_children = self._get_data(url, params)
         for device in response_children['data']:
             if device['product_id'] == PROD_ID.FLAP: # Catflap
@@ -413,20 +413,20 @@ class SurePetFlapAPI(object):
         household['default_flap'] = flaps[0]
         household['default_router'] = routers[0]
 
-    def update_pet_info(self, hid = None, force = False):
+    def update_pet_info( self, household_id = None, force = False ):
         """
         Update cache with pet information.
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
-        household = self.households[hid]
+        household_id = household_id or self.default_household
+        household = self.households[household_id]
         if household.get('pets') is not None and not force:
             return
         params = (
             ('with[]', ['photo', 'tag']),
         )
-        url = '%s/%s/pet' % (_URL_HOUSEHOLD, hid,)
+        url = '%s/%s/pet' % (_URL_HOUSEHOLD, household_id,)
         response_pets = self._get_data(url, params)
         household['pets'] = {
             x['id']: {'name': x['name'],
@@ -435,20 +435,20 @@ class SurePetFlapAPI(object):
                       } for x in response_pets['data']
             }
 
-    def update_flap_status(self, hid = None):
+    def update_flap_status( self, household_id = None ):
         """
         Update flap status.  Default household used if not specified.
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
-        household = self.households[hid]
-        for fid in household['flaps']:
-            url = '%s/%s/status' % (_URL_DEV, fid,)
+        household_id = household_id or self.default_household
+        household = self.households[household_id]
+        for flap_id in household['flaps']:
+            url = '%s/%s/status' % (_URL_DEV, flap_id,)
             response = self._get_data(url)
-            self.cache['flap_status'].setdefault( hid, {} )[fid] = response['data']
+            self.cache['flap_status'].setdefault( household_id, {} )[flap_id] = response['data']
 
-    def update_router_status(self, hid = None):
+    def update_router_status( self, household_id = None ):
         """
         Update router status.  Don't call unless you really need to because
         there's not much of interest here.  Default household used if not
@@ -456,72 +456,72 @@ class SurePetFlapAPI(object):
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
-        household = self.households[hid]
+        household_id = household_id or self.default_household
+        household = self.households[household_id]
         for rid in household['routers']:
             url = '%s/%s/status' % (_URL_DEV, rid,)
             response = self._get_data(url)
-            self.cache['router_status'].setdefault( hid, {} )[rid] = response['data']
+            self.cache['router_status'].setdefault( household_id, {} )[rid] = response['data']
 
-    def update_house_timeline(self, hid = None):
+    def update_house_timeline( self, household_id = None ):
         """
         Update household event timeline and curfew lock status.  Default
         household used if not specified.
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
+        household_id = household_id or self.default_household
         params = (
             ('type', '0,3,6,7,12,13,14,17,19,20'),
         )
-        url = '%s/household/%s' % (_URL_TIMELINE, hid,)
+        url = '%s/household/%s' % (_URL_TIMELINE, household_id,)
         response = self._get_data(url, params)
-        htl = self.cache['house_timeline'][hid] = response['data']
+        htl = self.cache['house_timeline'][household_id] = response['data']
         curfew_events = [x for x in htl if x['type'] == EVT.CURFEW]
         if curfew_events:
             # Serialised JSON within a serialised JSON structure?!  Weird.
-            self.cache['curfew_locked'][hid] = json.loads(curfew_events[0]['data'])['locked']
+            self.cache['curfew_locked'][household_id] = json.loads(curfew_events[0]['data'])['locked']
         else:
             # new accounts might not be populated with the relevent information
-            self.cache['curfew_locked'][hid] = None
+            self.cache['curfew_locked'][household_id] = None
 
-    def update_pet_status(self, hid = None):
+    def update_pet_status( self, household_id = None ):
         """
         Update pet status.  Default household used if not specified.
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
-        self.cache['pet_status'][hid] = {}
-        for pid in self.get_pets( hid ):
-            url = '%s/%s/position' % (_URL_PET, pid,)
+        household_id = household_id or self.default_household
+        self.cache['pet_status'][household_id] = {}
+        for pet_id in self.get_pets( household_id ):
+            url = '%s/%s/position' % (_URL_PET, pet_id,)
             headers = self._create_header()
             response = self._get_data(url)
-            self.cache['pet_status'][hid][pid] = response['data']
+            self.cache['pet_status'][household_id][pet_id] = response['data']
 
-    def update_pet_timeline(self, hid = None):
+    def update_pet_timeline( self, household_id = None ):
         """
         Update pet timeline.  Default household used if not specified.
         """
         if self.__read_only:
             raise SPAPIReadOnly()
-        hid = hid or self.default_household
-        household = self.households[hid]
+        household_id = household_id or self.default_household
+        household = self.households[household_id]
         params = (
             ('type', '0,3,6,7,12,13,14,17,19,20'),
         )
         petdata={}
-        for pid in household['pets']:
-            url = '%s/pet/%s/%s' % (_URL_TIMELINE, pid, hid,)
+        for pet_id in household['pets']:
+            url = '%s/pet/%s/%s' % (_URL_TIMELINE, pet_id, household_id,)
             response = self._get_data(url, params=params)
-            petdata[pid] = response['data']
-        self.cache['pet_timeline'][hid] = petdata
+            petdata[pet_id] = response['data']
+        self.cache['pet_timeline'][household_id] = petdata
 
     #
     # Low level remote API wrappers.  Do not use.
     #
 
-    def _get_data(self, url, params=None):
+    def _get_data( self, url, params = None ):
         if self.__read_only:
             raise SPAPIReadOnly()
         headers = None
@@ -552,7 +552,7 @@ class SurePetFlapAPI(object):
                 }
         return self.cache[url]['LastData']
 
-    def _create_header(self, ETag=None):
+    def _create_header( self, ETag = None ):
         headers={
             'Connection': 'keep-alive',
             'Accept': 'application/json, text/plain, */*',
@@ -656,7 +656,7 @@ class SurePetFlapMixin( object ):
     A mixin that implements introspection of data collected by SurePetFlapAPI.
     """
 
-    def print_timeline(self, pet_id = None, name = None, entry_type = None, household_id = None):
+    def print_timeline( self, pet_id = None, name = None, entry_type = None, household_id = None ):
         """
         Print timeline for a particular pet, specify entry_type to only get one
         direction.  Default household is used if not specified.
@@ -688,7 +688,7 @@ class SurePetFlapMixin( object ):
             except Exception as e:
                 print(e)
 
-    def locked(self, flap_id = None, household_id = None):
+    def locked( self, flap_id = None, household_id = None ):
         """
         Return whether door is locked or not.  Default household and flap used
         if not specified.
@@ -708,7 +708,7 @@ class SurePetFlapMixin( object ):
             else:
                 return False
 
-    def lock_mode(self, flap_id = None, household_id = None):
+    def lock_mode( self, flap_id = None, household_id = None ):
         """
         Returns a string describing the flap lock mode.  Default household and
         flap used if not specified.
@@ -729,7 +729,7 @@ class SurePetFlapMixin( object ):
         elif lock == LK_MOD.CURFEW_UNLOCKED:
             return 'Unlocked with curfew'
 
-    def get_current_status(self, petid=None, name=None, household_id = None):
+    def get_current_status( self, pet_id = None, name = None, household_id = None ):
         """
         Returns a string describing the last known movement of the pet.
 
@@ -738,12 +738,12 @@ class SurePetFlapMixin( object ):
         they're inside when in fact they're outside.  The same limitation
         presumably applies to the official website and app.
         """
-        if petid is None and name is None:
-            raise ValueError('Please define petid or name')
-        if petid is None:
-            petid = self.get_pet_id_by_name(name)
-        petid=int(petid)
-        loc = self.get_pet_location( petid, household_id )
+        if pet_id is None and name is None:
+            raise ValueError('Please define pet_id or name')
+        if pet_id is None:
+            pet_id = self.get_pet_id_by_name(name)
+        pet_id = int(pet_id)
+        loc = self.get_pet_location( pet_id, household_id )
         if loc == LOC.UNKNOWN:
             return 'Unknown'
         else:
@@ -751,7 +751,7 @@ class SurePetFlapMixin( object ):
             return INOUT_STATUS[loc]
 
 
-class SurePetFlap(SurePetFlapMixin, SurePetFlapAPI):
+class SurePetFlap( SurePetFlapMixin, SurePetFlapAPI ):
     """Class to take care of network communication with SurePet's products.
 
     See docstring for parent classes on how to use.  In particular, **please**

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -16,6 +16,7 @@ INOUT_STATUS = {1 : 'Inside', 2 : 'Outside'}
 EVT = mk_enum( 'EVT',
                {'MOVE': 0,
                 'MOVE_UID': 7, # movement of unknown animal
+                'BAT_WARN': 1,
                 'LOCK_ST': 6,
                 'USR_IFO': 12,
                 'USR_NEW': 17,
@@ -504,7 +505,7 @@ class SurePetFlapMixin( object ):
         petdata = self.pet_timeline[household_id][pet_id]
 
         for movement in petdata:
-            if movement['type'] in [EVT.MOVE_UID, EVT.LOCK_ST, EVT.USR_IFO, EVT.USR_NEW, EVT.CURFEW]:
+            if movement['type'] in [EVT.MOVE_UID, EVT.LOCK_ST, EVT.USR_IFO, EVT.USR_NEW, EVT.CURFEW, EVT.BAT_WARN,]:
                 continue
             try:
                 if entry_type is not None:
@@ -572,7 +573,7 @@ class SurePetFlapMixin( object ):
         if petid is None:
             petid = self.get_pet_id_by_name(name)
         petid=int(petid)
-        loc = get_pet_location( pet_id, household_id )
+        loc = self.get_pet_location( petid, household_id )
         if loc == LOC.UNKNOWN:
             return 'Unknown'
         else:

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -180,6 +180,24 @@ class SurePetFlap(object):
         self.tcache[url]['ts'] = datetime.now()
         return self.tcache[url]['LastData']
 
+    def create_header(self, ETag=None):
+        headers={
+            'Connection': 'keep-alive',
+            'Accept': 'application/json, text/plain, */*',
+            'Origin': 'https://surepetcare.io',
+            'User-Agent': API_USER_AGENT,
+            'Referer': 'https://surepetcare.io/',
+            'Accept-Encoding': 'gzip, deflate',
+            'Accept-Language': 'en-US,en-GB;q=0.9',
+            'X-Requested-With': 'com.sureflap.surepetcare',
+        }
+
+        if self.pcache['AuthToken'] is not None:
+            headers['Authorization']='Bearer ' + self.pcache['AuthToken']
+        if ETag is not None:
+            headers['If-None-Match'] = ETag
+        return headers
+
     def api_get( self, url, *args, **kwargs ):
         r = self.s.get( url, *args, **kwargs )
         if r.status_code == 401:
@@ -284,24 +302,6 @@ class SurePetFlap(object):
                 if movement['movements'][0]['direction'] != 0:
                     return STATUS_INOUT[movement['movements'][0]['direction']]
             return 'Unknown'
-
-    def create_header(self, ETag=None):
-        headers={
-            'Connection': 'keep-alive',
-            'Accept': 'application/json, text/plain, */*',
-            'Origin': 'https://surepetcare.io',
-            'User-Agent': API_USER_AGENT,
-            'Referer': 'https://surepetcare.io/',
-            'Accept-Encoding': 'gzip, deflate',
-            'Accept-Language': 'en-US,en-GB;q=0.9',
-            'X-Requested-With': 'com.sureflap.surepetcare',
-        }
-
-        if self.pcache['AuthToken'] is not None:
-            headers['Authorization']='Bearer ' + self.pcache['AuthToken']
-        if ETag is not None:
-            headers['If-None-Match'] = ETag
-        return headers
 
     def debug_print(self, string):
         if self.debug:

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -170,7 +170,7 @@ class SurePetFlapAPI(object):
         household_id = household_id or self.default_household
         flap_id = flap_id or self.get_default_flap( household_id )
         try:
-            return self.flap_status[household_id][flap_id]['battery'] / 4.0
+            return self.all_flap_status[household_id][flap_id]['battery'] / 4.0
         except KeyError:
             raise SPAPIUnitialised()
 
@@ -202,9 +202,9 @@ class SurePetFlapAPI(object):
         Default household used if not specified.
         """
         household_id = household_id or self.default_household
-        if pet_id not in self.pet_status[household_id]:
+        if pet_id not in self.all_pet_status[household_id]:
             raise SPAPIUnknownPet()
-        return self.pet_status[household_id][pet_id]['where']
+        return self.all_pet_status[household_id][pet_id]['where']
 
     def get_lock_mode( self, flap_id = None, household_id = None ):
         """
@@ -215,7 +215,7 @@ class SurePetFlapAPI(object):
         household = self.households[household_id]
         if flap_id is None:
             flap_id = household['default_flap']
-        mode = self.flap_status[household_id][flap_id]['locking']['mode']
+        mode = self.all_flap_status[household_id][flap_id]['locking']['mode']
         if mode == LK_MOD.CURFEW:
             if self.curfew_locked[household_id] is None:
                 mode = LK_MOD.CURFEW_UNKNOWN
@@ -299,18 +299,34 @@ class SurePetFlapAPI(object):
         return self.cache['router_status']
     @property
     def flap_status( self ):
+        "Dict of all flaps for default household"
+        return self.all_flap_status[self.default_household]
+    @property
+    def all_flap_status( self ):
         "Dict of all flaps indexed by household and router IDs"
         return self.cache['flap_status']
     @property
     def pet_status( self ):
+        "Dict of all pets for default household"
+        return self.all_pet_status[self.default_household]
+    @property
+    def all_pet_status( self ):
         "Dict of all pets indexed by household and pet IDs"
         return self.cache['pet_status']
     @property
     def pet_timeline( self ):
+        "Pet events for default household"
+        return self.all_pet_timeline[self.default_household]
+    @property
+    def all_pet_timeline( self ):
         "Dict of pet events indexed by household ID"
         return self.cache['pet_timeline']
     @property
     def house_timeline( self ):
+        "Events for default household"
+        return self.all_house_timeline[self.default_household]
+    @property
+    def all_house_timeline( self ):
         "Dict of household events indexed by household ID"
         return self.cache['house_timeline']
     @property
@@ -672,7 +688,7 @@ class SurePetFlapMixin( object ):
             pet_name = self.household['pets'][pet_id]['name']
         except KeyError as e:
             raise SPAPIUnknownPet( str(e) )
-        petdata = self.pet_timeline[household_id][pet_id]
+        petdata = self.all_pet_timeline[household_id][pet_id]
 
         for movement in petdata:
             if movement['type'] in [EVT.MOVE_UID, EVT.LOCK_ST, EVT.USR_IFO, EVT.USR_NEW, EVT.CURFEW, EVT.BAT_WARN,]:
@@ -697,7 +713,7 @@ class SurePetFlapMixin( object ):
         household = self.households[household_id]
         if flap_id is None:
             flap_id = household['default_flap']
-        lock = self.flap_status[household_id][flap_id]['locking']['mode']
+        lock = self.all_flap_status[household_id][flap_id]['locking']['mode']
         if lock == LK_MOD.UNLOCKED:
             return False
         if lock in [LK_MOD.LOCKED_IN, LK_MOD.LOCKED_OUT, LK_MOD.LOCKED_ALL,]:

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -262,6 +262,7 @@ class SurePetFlapMixin( object ):
         """Print timeline for a particular pet, specify entry_type to only get one direction"""
         try:
             tag_id = self.pcache['pets'][petid]['tag_id']
+            pet_name = self.pcache['pets'][petid]['name']
         except KeyError as e:
             raise SPAPIUnknownPet( str(e) )
         petdata = self.petstatus[petid]
@@ -273,10 +274,10 @@ class SurePetFlapMixin( object ):
                 if entry_type is not None:
                     if movement['movements'][0]['tag_id'] == tag_id:
                         if movement['movements'][0]['direction'] == entry_type:
-                            print(movement['movements'][0]['created_at'], DIRECTION[movement['movements'][0]['direction']])
+                            print(movement['movements'][0]['created_at'], pet_name, DIRECTION[movement['movements'][0]['direction']])
                 else:
                     if movement['movements'][0]['tag_id'] == tag_id:
-                        print(movement['movements'][0]['created_at'], DIRECTION[movement['movements'][0]['direction']])
+                        print(movement['movements'][0]['created_at'], pet_name, DIRECTION[movement['movements'][0]['direction']])
             except Exception as e:
                 print(e)
 

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -615,6 +615,7 @@ class SurePetFlapAPI(object):
                           'pet_timeline': {}, # indexed by household
                           'house_timeline': {}, # indexed by household
                           'curfew_locked': {}, # indexed by household
+                          'version': 1 # of cache structure.
                           }
 
     def __enter__( self ):

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -533,6 +533,8 @@ class SurePetFlapAPI(object):
                 # server error, server overload, server unavailable and gateway
                 # timeout.  Doesn't cope with such events absent cached data,
                 # but hopefully that is sufficiently rare not to bother with.
+                if response.status_code == 404:
+                    raise IndexError( url )
                 if response.status_code == 304:
                     # Can only get here if there is a cached response
                     self.cache[url]['ts'] = datetime.now()

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -161,6 +161,17 @@ class SurePetFlapAPI(object):
         hid = hid or self.default_household
         return self.cache['households'][hid]['pets']
 
+    def get_pet_id_by_name(self, name, household_id = None):
+        """
+        Returns the numeric ID (not the tag ID) of the pet by name.  Match is
+        case insensitive and the first pet found with that name is returned.
+        Default household used if not specified.
+        """
+        household_id = household_id or self.default_household
+        for petid, petdata in self.cache['households'][household_id]['pets'].items():
+            if petdata['name'].lower() == name.lower():
+                return petid
+
     def update(self):
         """
         Update everything.  MUST be invoked immediately after instance creation
@@ -480,17 +491,6 @@ class SurePetFlapMixin( object ):
             else:
                 return 'Unlocked with curfew'
 
-    def find_id(self, name, household_id = None):
-        """
-        Returns the numeric ID (not the tag ID) of the pet by name.  Match is
-        case insensitive and the first pet found with that name is returned.
-        Default household used if not specified.
-        """
-        household_id = household_id or self.default_household
-        for petid, petdata in self.cache['households'][household_id]['pets'].items():
-            if petdata['name'].lower() == name.lower():
-                return petid
-
     def get_current_status(self, petid=None, name=None, household_id = None):
         """
         Returns a string describing the last known movement of the pet.
@@ -504,7 +504,7 @@ class SurePetFlapMixin( object ):
         if petid is None and name is None:
             raise ValueError('Please define petid or name')
         if petid is None:
-            petid = self.find_id(name)
+            petid = self.get_pet_id_by_name(name)
         petid=int(petid)
         if not int(petid) in self.pet_status[household_id]:
             return 'Unknown'

--- a/sure_petcare/__init__.py
+++ b/sure_petcare/__init__.py
@@ -45,7 +45,7 @@ _URL_TIMELINE = 'https://app.api.surehub.io/api/timeline'
 API_USER_AGENT = 'Mozilla/5.0 (Linux; Android 7.0; SM-G930F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36'
 
 
-class SurePetFlapNetwork(object):
+class SurePetFlapAPI(object):
     """Class to take care of network communication with SurePet's products.
 
     Unless you want to parse data from Sure directly, instantiate SurePetFlap()
@@ -402,7 +402,7 @@ class SurePetFlapNetwork(object):
 
 class SurePetFlapMixin( object ):
     """
-    A mixin that implements introspection of data collected by SurePetFlapNetwork.
+    A mixin that implements introspection of data collected by SurePetFlapAPI.
     """
 
     def print_timeline(self, pet_id, entry_type = None, household_id = None):
@@ -518,7 +518,7 @@ class SurePetFlapMixin( object ):
             return 'Unknown'
 
 
-class SurePetFlap(SurePetFlapMixin, SurePetFlapNetwork):
+class SurePetFlap(SurePetFlapMixin, SurePetFlapAPI):
     """Class to take care of network communication with SurePet's products.
 
     See docstring for parent classes on how to use.  In particular, **please**

--- a/sure_petcare/utils.py
+++ b/sure_petcare/utils.py
@@ -1,0 +1,55 @@
+import os
+
+def mk_enum( name, kv ):
+    """
+    Emulate enum types found in other languages.
+
+    `name` is the type name to which the enum will be assigned.
+
+    `kv` is either a dict of string -> value mappings or a simple list of
+    strings.  In the latter case, numeric values will automatically be assigned.
+    """
+    if type(kv) is list:
+        kv = dict( zip( kv, range(len(kv)) ) )
+
+    class Cls(object):
+        __class__ = name
+        def __init__( self, d ):
+            self._data = d
+        def __getattr__( self, name ):
+            return self._data[name]
+        def find( self, target ):
+            return ['%s.%s' % (self.__class__,k,) for k, v in self._data.items() if v == target]
+
+    return Cls( kv )
+
+
+def getmac():
+    """
+    Hackish way to obtain an unspecified MAC address.
+    """
+    mac = None
+    folders = os.listdir('/sys/class/net/')
+    for interface in folders:
+        if interface == 'lo':
+            continue
+        try:
+            mac = open('/sys/class/net/'+interface+'/address').readline()
+            # XXX What happens when multiple interfaces are found?  Might
+            #     be better to break here to stop at the first MAC which,
+            #     on most/many systems, will be the first wired Ethernet
+            #     interface.
+            # break
+        except Exception as e:
+            return None
+    if mac is not None:
+        return mac.strip() #trim new line
+
+
+def gen_device_id():
+    """
+    Generates a "unique" client device ID based on MAC address.
+    """
+    mac_dec = int( getmac().replace( ':', '').replace( '-', '' ), 16 )
+    # Use low order bits because upper two octets are low entropy
+    return str(mac_dec)[-10:]


### PR DESCRIPTION
This is a substantial rewrite with two objectives in mind: to make as few back-end REST requests as possible (which is crucial in terms of avoiding sanctions against your account for abuse of Sure's infrastructure) and to make the API better-suited to programmatic applications.

A number of feature enhancements and additions have also been made.  The principal contributions of this PR are:

 * Performance and efficiency:
    * Introduce built-in disc-backed persistent caching with locking to complement pre-existing ETag if-none-match mechanism
    * Rate limiting (queries served from cache rather than block)
    * Reimplement pet timeline to avoid calls for data already held in the house timeline
    * House timeline now not required for other features (including pet status and curfew condition), so only update the timeline if you really need it.
  * Improved robustness:
    * Curfew lock condition now extracted directly from device status (which is now included in the REST response) rather than iterating over the house timeline which could result in unknown statuses, especially after the revised API or June 19 reduced the number of events returned per call.
    * Add pet location REST call rather than iterating over house timeline.  For typical users, this means the same number of calls but with much smaller payload
    * The likelihood of an exception being thrown by the constructor is greatly reduced because it no longer invokes any network activity.  This does mean that the API doesn't automatically update itself (see below) and also means that you can be **selective** about what you update to avoid unnecessary REST traffic.
    * Authorisation is automatically refreshed when required.  It is not necessary to poll for the AuthToken.
    * Transient back-end errors (5xx) and not found errors (404) handled appropriately
  * Improved machine interface:
    * Exceptions thrown to deal with problems rather than returning results that could be construed as valid responses.  This could be improved upon further, but there's better error-checking than there was.
    * Class is split into back-end component (`SurePetFlapAPI`) and separate query class (`SurePetFlapMixin`) query interface.  `SurePetFlap` is the combination of the two, but users can create their own query mixins if they wish.
    * Use of enumerations better suited to machine clients rather than text strings for human consumption.  These are turned into the same text strings as before by the query mixin.
    * Because credentials are cached along with pretty much everything else, the API can be instantiated with no constructor arguments at all once the cache has been initialised (which can be done with the CLI tool if convenient).
  * Added a simplistic but easily extensible CLI tool.  Network activity is separated from queries, so the CLI can be invoked multiple times without generating any network activity.
  * Added support for multiple flaps per router (hub), multiple hubs per household and multiple households per account.  To accommodate this change, a number of property methods (getters only) have been added to access the default household consistent with the interface as it stands before merge.
  * Add battery state call.
  * Add support for events: battery warning, unidentified animal movement, user added
  * Bug fixes, notably to `print_timeline()` method.

The code in this PR is not 100% backwards compatible.  One or two methods have been renamed, but chances are not ones you may use directly.

The main change required by any user of this API is to enclose calls to any of the update methods inside `with ...:` context block.  When the block exits, the cache is flushed back to disc.  The cache is only locked for the duration of the context block, so you can query it as much as you like from as many instances as you like provided only one instance at any one time is performing an update.  Example:

```
api = sure_petcare.SurePetFlap()
pet_id = # appropriate ID or code here
with api:
    # You are **strongly** encouraged to update only things you need to update.
    # `update_timeline()` is particularly expensive so, if you don't need it, don't call it.
    api.update_pet_status()
print( api.pets[pet_id]['name'], api.get_current_status api.get_current_status( pet_id ) )
```